### PR TITLE
Fix: Updated template to read transaction_id from GA4 event model

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -845,7 +845,11 @@ if (eventModel.num_items) {
   event.custom_data.num_items = eventModel.items.length;
 }
 // order_id
-if (eventModel.order_id) {
+// standard mapping from GA4 data model
+if (eventModel.transaction_id) {
+  event.custom_data.order_id = eventModel.transaction_id;
+} // for backwards compatibility for users that set order_id
+else if (eventModel.order_id) {
   event.custom_data.order_id = eventModel.order_id;
 }
 // search_string
@@ -2002,6 +2006,30 @@ scenarios:
     // num_items
     let actual_num_items = JSON.parse(httpBody).data[0].custom_data.num_items;
     assertThat(JSON.parse(httpBody).data[0].custom_data.contents.length).isEqualTo(items.length);
+- name: On receiving ‘transaction_id’ or ‘order_id’ from GA4 event, Tag parses them
+    into ‘order_id’ for cAPI
+  code: |-
+    // Act
+    mock('getAllEventData', () => {
+      inputEventModel.order_id = undefined;
+      inputEventModel.transaction_id = 'transaction_id';
+      return inputEventModel;
+    });
+    runCode(testConfigurationData);
+
+    //Assert
+    assertThat(JSON.parse(httpBody).data[0].custom_data.order_id).isEqualTo("transaction_id");
+
+    // Act
+    mock('getAllEventData', () => {
+      inputEventModel.transaction_id = undefined;
+      inputEventModel.order_id = 'order_id';
+      return inputEventModel;
+    });
+    runCode(testConfigurationData);
+
+    //Assert
+    assertThat(JSON.parse(httpBody).data[0].custom_data.order_id).isEqualTo("order_id");
 setup: |-
   // Arrange
   const JSON = require('JSON');


### PR DESCRIPTION
As per the official documentation, the standard GA4 parameter is 'transaction_id', but the template is currently mapping custom_data.order_id from eventModel.order_id.
https://developers.google.com/analytics/devguides/collection/ga4/reference/events?sjid=8478538619747073168-EU&client_type=gtm#purchase
Updated the template to pull from eventModel.transaction_id instead, but maintained backward compatibility for those users setting order_id.
Added a test to ensure that both parameters will work (but preferring the official parameter - transaction_id).
